### PR TITLE
Changed WEB_KIOSK_EXPORT_MODE environment variable to 'full' for stages other than 'prod'.

### DIFF
--- a/deploy/cdk/lib/deploy-stack.ts
+++ b/deploy/cdk/lib/deploy-stack.ts
@@ -77,7 +77,7 @@ export class MarbleWebKioskExportStack extends cdk.Stack {
           // ],
           environment: {
               SSM_KEY_BASE: `/all/marble-data-processing/${stage === 'prod' ? 'prod' : 'test'}`,
-              WEB_KIOSK_EXPORT_MODE: 'incremental'
+              WEB_KIOSK_EXPORT_MODE: `${stage === 'prod' ? 'incremental' : 'full'}`
           },
           role: embarkLambdaRole,
           timeout: cdk.Duration.seconds(900),


### PR DESCRIPTION
This change simplifies testing the pipeline deploy, guaranteeing there will be metadata to test (generating a "full" export).  Previously, we were generating an "incremental" export, which only exported files for metadata that had changed within the last 24 hours.  Since we cannot control when metadata changes, this testing was dubious.